### PR TITLE
Simplify reading a file

### DIFF
--- a/app/content/how-do-i/simple/read-a-file-from-disk.md
+++ b/app/content/how-do-i/simple/read-a-file-from-disk.md
@@ -2,14 +2,10 @@
 title: read a file from disk
 ---
 
-Reading a file opens a handle to the file. You can use `openFile` to open a handle to the file and `hClose` to close the handle when you're done.
-However, the `withFile` function closes the handle automatically for you, so it's a safer choice:
+Use `readFile`:
 
 ```Haskell
-import System.IO     
-    
-main = do     
-    withFile "file.txt" ReadMode (\handle -> do  
-        contents <- hGetContents handle     
-        putStr contents)  
-``` 
+main = do
+    contents <- readFile "file.txt"
+    putStr contents
+```     


### PR DESCRIPTION
[<geekosaur> that code has a hidden gotcha because hGetContents is lazy. readFile is safer](http://ircbrowse.net/browse/haskell?id=23180461&timestamp=1470497212#t1470497212)

This version is better than the previous one, but no better than finding `readFile` in the Prelude documentation, and no easier to find than it. Therefore, this should be removed?
